### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/git-annex.elc


### PR DESCRIPTION
Hi John,

I have git-annex-el installed as a submodule of my .emacs.d git repo. It's quite handy to have, thanks. The built file git-annex.elc makes git think something has changed in the submodule, so it comes up red in git status... hence this pull request.

Cheers,

Rodney
