### PR TITLE
Advise read-only-mode.

### DIFF
--- a/git-annex.el
+++ b/git-annex.el
@@ -59,7 +59,7 @@ otherwise you will have to commit by hand.")
   (when git-annex-commit
     (call-process "git" nil nil nil "commit" "-m" "Updated")))
 
-(defadvice toggle-read-only (before git-annex-edit-file activate)
+(defun git-annex--toggle-unlock ()
   (when (string=
 		 (vc-backend buffer-file-name)
 		 "Git"
@@ -93,6 +93,12 @@ otherwise you will have to commit by hand.")
 			  (goto-char here)))
 		(setq buffer-read-only nil)))))
   )
+
+(defadvice toggle-read-only (before git-annex-edit-file activate)
+  (git-annex--toggle-unlock))
+
+(defadvice read-only-mode (before git-annex-edit-file activate)
+  (git-annex--toggle-unlock))
 
 (defface git-annex-dired-annexed-available
   '((((class color) (background dark))


### PR DESCRIPTION
toggle-read-only has been deprecated as of Emacs 24.3 and is a wrapper
around read-only-mode. We now advise read-only-mode so that the desired
behavior is triggered. The advice to the deprecated function is left in
place for now.