### PR TITLE
Specify type attribute

### DIFF
--- a/git-annex.el
+++ b/git-annex.el
@@ -49,7 +49,8 @@
 (defcustom git-annex-commit t
   "If not nil, git-annex command will commit by default.
 
-otherwise you will have to commit by hand.")
+otherwise you will have to commit by hand."
+  :type 'boolean)
 
 (defsubst git-annex (&rest args)
   (apply #'call-process "git" nil nil nil "annex" args))


### PR DESCRIPTION
Missing variable type causes byte-compile warning from Emacs 26.