### PR TITLE
Search until a file exists or we reach the search limit

### DIFF
--- a/git-annex.el
+++ b/git-annex.el
@@ -128,9 +128,10 @@ otherwise you will have to commit by hand."
   "Face name used to hide a git-annex'd file's annex path.")
 
 (defun git-annex-lookup-file (limit)
-  (and (re-search-forward " -> \\(.*\\.git/annex/.+\\)" limit t)
-       (file-exists-p
-        (expand-file-name (match-string 1) (dired-current-directory)))))
+  (cl-loop while (re-search-forward " -> \\(.*\\.git/annex/.+\\)" limit t)
+           if (file-exists-p
+               (expand-file-name (match-string 1) (dired-current-directory)))
+           return t))
 
 (eval-after-load "dired"
   '(progn


### PR DESCRIPTION
Fixes an issue where some files are incorrectly shown as
 "unavailable". This happens when font lock passes
 `git-annex-lookup-file` a large limit, but the first file the function
 encounters is unavailable. Font lock takes this to mean that no
 fontification should occur up to the limit, skipping files that might
 actually be available.