### PR TITLE
Use the file's parent directory to expand relative symlinks

### DIFF
--- a/git-annex.el
+++ b/git-annex.el
@@ -130,7 +130,7 @@ otherwise you will have to commit by hand."
 (defun git-annex-lookup-file (limit)
   (cl-loop while (re-search-forward " -> \\(.*\\.git/annex/.+\\)" limit t)
            if (file-exists-p
-               (expand-file-name (match-string 1) (dired-current-directory)))
+               (expand-file-name (match-string 1) (file-name-directory (dired-get-filename nil t))))
            return t))
 
 (eval-after-load "dired"


### PR DESCRIPTION
File names in dired can sometimes contain directories (for example,
when using "find-dired"). Using "dired-current-directory" to expand
git annex's relative symlinks in this way can be incorrect, and
incorrectly show available files as being unavailable.

Here we use "dired-get-filename" to get the full file name at point,
then use "file-name-directory" to get the file's parent
directory. This should give us the correct directory with which to
expand the git annex relative symlink.