### PR TITLE
Executable files are not font locked properly

### DIFF
--- a/git-annex.el
+++ b/git-annex.el
@@ -128,9 +128,9 @@ otherwise you will have to commit by hand."
   "Face name used to hide a git-annex'd file's annex path.")
 
 (defun git-annex-lookup-file (limit)
-  (cl-loop while (re-search-forward " -> \\(.*\\.git/annex/.+\\)" limit t)
+  (cl-loop while (re-search-forward " -> .*\\.git/annex/.+" limit t)
            if (file-exists-p
-               (expand-file-name (match-string 1) (file-name-directory (dired-get-filename nil t))))
+               (file-truename (dired-get-filename nil t)))
            return t))
 
 (eval-after-load "dired"


### PR DESCRIPTION
I'm running emacs in WSL under Windows.
I noticed that git-annex.el marks executable files as unavailable, even though they are available.

I traced it back to the call of `git-annex-lookup-file` which extracts the actual filename with a regexp.
However this matches something like "../.git/annex/objects/path/file.sh*" with the trailing `*` for executable files.
And then `file-exists-p` can not find a file with the trailing `*` in its name as only "../.git/annex/objects/path/file.sh" without the `*` exists.

Using `file-truename` also fixes the lookup if the annex repo is accessed over another symlink.
